### PR TITLE
fix: fix auto import React syntax_context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ name = "plugin_react_utils"
 version = "0.1.0"
 dependencies = [
  "shared",
+ "test_plugins",
 ]
 
 [[package]]

--- a/crates/binding/src/binding_types/plugin_react_utils.rs
+++ b/crates/binding/src/binding_types/plugin_react_utils.rs
@@ -18,8 +18,8 @@ pub struct ReactUtilsConfigNapi {
 impl IntoRawConfig<ReactUtilsConfig> for ReactUtilsConfigNapi {
   fn into_raw_config(self, _: Env) -> napi::Result<ReactUtilsConfig> {
     Ok(ReactUtilsConfig {
-      auto_import_react: self.auto_import_react,
-      rm_effect: self.rm_effect,
+      auto_import_react: self.auto_import_react.unwrap_or(false),
+      rm_effect: self.rm_effect.unwrap_or(false),
     })
   }
 }

--- a/crates/core/src/pass.rs
+++ b/crates/core/src/pass.rs
@@ -37,7 +37,7 @@ pub fn internal_transform_pass(
     .unwrap_or_else(|| Either::Right(noop()));
 
   let react_utils = if let Some(c) = &extensions.react_utils {
-    Either::Left(react_utils(c))
+    Either::Left(react_utils(c, top_level_mark))
   } else {
     Either::Right(noop())
   };

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -38,7 +38,7 @@ pub fn transform(
           swc_config.config.input_source_map = input_source_map.map(config::InputSourceMap::Str);
           swc_config.filename = filename;
 
-          let top_level_mark = swc_config.top_level_mark.unwrap_or_else(Mark::new);
+          let top_level_mark = Mark::new();
           let unresolved_mark = Mark::new();
 
           swc_config.top_level_mark = Some(top_level_mark);

--- a/crates/plugin_modularize_imports/tests/fixture.rs
+++ b/crates/plugin_modularize_imports/tests/fixture.rs
@@ -64,6 +64,5 @@ fn modularize_imports_fixture(input: PathBuf) {
     },
     &input,
     &output,
-    Default::default()
   );
 }

--- a/crates/plugin_react_utils/Cargo.toml
+++ b/crates/plugin_react_utils/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 shared = {path="../shared"}
+
+[dev_dependencies]
+test_plugins = {path="../test_plugins"}

--- a/crates/plugin_react_utils/src/lib.rs
+++ b/crates/plugin_react_utils/src/lib.rs
@@ -1,4 +1,5 @@
 use shared::serde::{self, Deserialize};
+use shared::swc_core::common::Mark;
 use shared::swc_core::{
   common::{chain, pass::Either,},
   ecma::{
@@ -13,21 +14,21 @@ mod remove_effect;
 pub use import_react::auto_import_react;
 pub use remove_effect::remove_effect;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default)]
 #[serde(crate = "self::serde")]
 pub struct ReactUtilsConfig {
-  pub auto_import_react: Option<bool>,
-  pub rm_effect: Option<bool>,
+  pub auto_import_react: bool,
+  pub rm_effect: bool,
 }
 
-pub fn react_utils(config: &ReactUtilsConfig) -> impl Fold {
+pub fn react_utils(config: &ReactUtilsConfig, top_level_mark: Mark) -> impl Fold {
   chain!(
-    if config.auto_import_react.unwrap_or(false) {
-      Either::Left(auto_import_react())
+    if config.auto_import_react {
+      Either::Left(auto_import_react(top_level_mark))
     } else {
       Either::Right(noop())
     },
-    if config.rm_effect.unwrap_or(false) {
+    if config.rm_effect {
       Either::Left(remove_effect())
     } else {
       Either::Right(noop())

--- a/crates/plugin_react_utils/tests/main.rs
+++ b/crates/plugin_react_utils/tests/main.rs
@@ -1,0 +1,24 @@
+use plugin_react_utils::ReactUtilsConfig;
+use test_plugins::{run_test, Extensions, TransformConfig};
+
+#[test]
+fn main() {
+  run_test(
+    "react",
+    &TransformConfig {
+      swc: Default::default(),
+      extensions: Extensions {
+        react_utils: Some(ReactUtilsConfig {
+          auto_import_react: true,
+          rm_effect: false,
+        }),
+        ..Default::default()
+      },
+    },
+    "console.log(React)",
+    Some(r#"
+    import React from "react";
+    console.log(React);"#),
+    None,
+  );
+}

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -2,6 +2,7 @@ use swc_core::{
   common::SyntaxContext,
   ecma::{
     ast::Ident,
+    atoms::JsWord,
     visit::{Fold, VisitMut},
   },
 };
@@ -40,24 +41,45 @@ macro_rules! helper_expr {
     $crate::helper_expr!($crate::swc_core::common::DUMMY_SP, $field_name, $s)
   }};
 
-  ($span:expr, $field_name:ident, $s:tt) => {
-    {
-      let mark = $crate::enable_helper!($field_name);
-      let span = $span.apply_mark(mark);
-      let external =
-        $crate::swc_core::ecma::transforms::base::helpers::HELPERS.with(|helper| helper.external());
-  
-      if external {
-        $crate::swc_core::ecma::ast::Expr::from($crate::swc_core::ecma::utils::quote_ident!(
-          span,
-          concat!("_", stringify!($field_name))
-        ))
-      } else {
-        $crate::swc_core::ecma::ast::Expr::from($crate::swc_core::ecma::utils::quote_ident!(
-          span,
-          concat!("_", $s)
-        ))
-      }
+  ($span:expr, $field_name:ident, $s:tt) => {{
+    let mark = $crate::enable_helper!($field_name);
+    let span = $span.apply_mark(mark);
+    let external =
+      $crate::swc_core::ecma::transforms::base::helpers::HELPERS.with(|helper| helper.external());
+
+    if external {
+      $crate::swc_core::ecma::ast::Expr::from($crate::swc_core::ecma::utils::quote_ident!(
+        span,
+        concat!("_", stringify!($field_name))
+      ))
+    } else {
+      $crate::swc_core::ecma::ast::Expr::from($crate::swc_core::ecma::utils::quote_ident!(
+        span,
+        concat!("_", $s)
+      ))
     }
-  };
+  }};
+}
+
+pub fn change_ident_syntax_context(ctxt: SyntaxContext, name: JsWord) -> impl VisitMut {
+  ChangeIdentSyntaxContext::new(ctxt, name)
+}
+
+pub struct ChangeIdentSyntaxContext {
+  pub ctxt: SyntaxContext,
+  pub name: JsWord,
+}
+
+impl ChangeIdentSyntaxContext {
+  fn new(ctxt: SyntaxContext, name: JsWord) -> Self {
+    ChangeIdentSyntaxContext { ctxt, name }
+  }
+}
+
+impl VisitMut for ChangeIdentSyntaxContext {
+  fn visit_mut_ident(&mut self, ident: &mut Ident) {
+    if ident.sym == self.name {
+      ident.span = ident.span.with_ctxt(self.ctxt);
+    }
+  }
 }


### PR DESCRIPTION
Fix plugin auto import react issue:

```javascript
import React from 'react'
-------^^^^^

console.log(React)
------------^^^^^
```

Those 2 must have the same syntax context