### PR TITLE
perf: cache plugin_lodash internal struct to reduce IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
 name = "plugin_lodash"
 version = "0.1.0"
 dependencies = [
+ "better_scoped_tls",
  "nodejs-resolver",
  "shared",
  "test_plugins",

--- a/crates/plugin_lodash/Cargo.toml
+++ b/crates/plugin_lodash/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+better_scoped_tls = "0.1.0"
 nodejs-resolver = "0.0.42"
 shared = {path="../shared"}
 
-[dev_dependencies]
+[dev-dependencies]
 test_plugins = {path="../test_plugins"}


### PR DESCRIPTION
Previous plugin_lodash implementation, there is no Cache for `nodejs resolve` result, and resolve package every transformation. Using a simple cache, to avoid re-resolve