### PR TITLE
feat: add cache implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.0",
  "anyhow",
+ "dashmap",
  "serde",
  "serde_json",
  "swc_core",

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -30,6 +30,7 @@ use swc_plugins_core::types::TransformConfig;
 
 // ===== Internal Rust struct under the hood =====
 pub struct Compiler {
+  pub id: u32,
   pub config: TransformConfig,
   pub swc_compiler: Arc<SwcCompiler>,
 }
@@ -64,6 +65,7 @@ impl JsCompiler {
     compilers.insert(
       id,
       Compiler {
+        id,
         config,
         swc_compiler: Arc::new(SwcCompiler::new(Arc::new(SourceMap::default()))),
       },
@@ -109,6 +111,7 @@ impl JsCompiler {
         filename,
         &code,
         map,
+        Some(compiler.id.to_string())
       )
       .map_err(|e| napi::Error::new(Status::GenericFailure, e.to_string()))
       .map(|transform_output| transform_output.into());
@@ -207,6 +210,7 @@ impl Task for TransformTask {
       self.filename.clone(),
       &self.code,
       self.map.clone(),
+      Some(compiler.id.to_string())
     )
     .map_err(|e| napi::Error::new(Status::GenericFailure, e.to_string()))
   }

--- a/crates/plugin_lock_corejs_version/tests/main.rs
+++ b/crates/plugin_lock_corejs_version/tests/main.rs
@@ -20,6 +20,7 @@ fn main() {
     config,
     BaseFixtureHook,
     vec![],
+    None
   );
 
   tester.fixtures(&current_dir().unwrap().join("tests/fixtures"));

--- a/crates/plugin_lodash/tests/main.rs
+++ b/crates/plugin_lodash/tests/main.rs
@@ -44,6 +44,7 @@ fn test_fixtures() {
     },
     BaseFixtureHook,
     vec![CachedRegex::new("error-fixtures").unwrap()],
+    Some("".into())
   );
 
   tester.fixtures(&cwd.join("tests/fixtures"));

--- a/crates/plugin_react_utils/tests/main.rs
+++ b/crates/plugin_react_utils/tests/main.rs
@@ -141,7 +141,8 @@ fn main() {
       }
     }"#).unwrap(),
     Hook{},
-    vec![]
+    vec![],
+    None
   );
 
   tester.fixtures(&fixture_dir);

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -31,6 +31,7 @@ swc_core = { features = [
   "testing_transform"
 ], version = "0.28.10" }
 ahash = "0.8.0"
+dashmap = "5.4.0"
 
 [dev-dependencies]
 testing_macros = "0.2.7"

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -9,10 +9,12 @@ pub use swc_core::ecma::transforms::testing as swc_ecma_transforms_testing;
 pub use testing;
 pub extern crate serde;
 pub use ahash;
+pub use dashmap;
 
 pub struct PluginContext {
   pub cm: Arc<SourceMap>,
   pub top_level_mark: Mark,
   pub unresolved_mark: Mark,
   pub comments: SingleThreadedComments,
+  pub config_hash: Option<String> // This can be used by plugins to do caching
 }

--- a/crates/swc_plugins_core/src/pass.rs
+++ b/crates/swc_plugins_core/src/pass.rs
@@ -5,7 +5,7 @@ use plugin_lock_corejs_version::lock_corejs_version;
 use plugin_lodash::plugin_lodash;
 use shared::{
   swc_core::{
-    common::{chain, comments::SingleThreadedComments, pass::Either, Mark, SourceMap},
+    common::{chain, pass::Either},
     ecma::transforms::base::pass::noop,
     ecma::visit::Fold,
   },
@@ -18,18 +18,8 @@ use plugin_react_utils::react_utils;
 
 pub fn internal_transform_before_pass(
   config: &TransformConfig,
-  cm: Arc<SourceMap>,
-  top_level_mark: Mark,
-  unresolved_mark: Mark,
-  comments: SingleThreadedComments,
+  plugin_context: Arc<PluginContext>,
 ) -> impl Fold + '_ {
-  let plugin_context = Arc::new(PluginContext {
-    cm,
-    top_level_mark,
-    unresolved_mark,
-    comments,
-  });
-
   let extensions = &config.extensions;
 
   let modularize_imports = extensions
@@ -82,10 +72,7 @@ pub fn internal_transform_before_pass(
 
 pub fn internal_transform_after_pass(
   config: &TransformConfig,
-  _cm: Arc<SourceMap>,
-  _top_level_mark: Mark,
-  _unresolved_mark: Mark,
-  _comments: SingleThreadedComments,
+  _plugin_context: Arc<PluginContext>,
 ) -> impl Fold + '_ {
   if let Some(config) = &config.extensions.lock_corejs_version {
     Either::Left(lock_corejs_version(

--- a/crates/swc_plugins_core/tests/main.rs
+++ b/crates/swc_plugins_core/tests/main.rs
@@ -31,6 +31,7 @@ fn test() {
     "".into(),
     code,
     None,
+    Some("".into())
   )
   .unwrap();
   insta::assert_snapshot!("plugin-import", res.code);

--- a/crates/test_plugins/src/lib.rs
+++ b/crates/test_plugins/src/lib.rs
@@ -39,6 +39,7 @@ where
   pub config: swc_plugins_core::types::TransformConfig,
   pub hooks: H,
   pub ignore: Vec<CachedRegex>,
+  pub config_hash: Option<String>
 }
 
 pub trait FixtureTesterHook {
@@ -92,11 +93,13 @@ where
     config: swc_plugins_core::types::TransformConfig,
     hooks: H,
     ignore: Vec<CachedRegex>,
+    config_hash: Option<String>,
   ) -> Self {
     Self {
       config,
       hooks,
       ignore,
+      config_hash
     }
   }
 
@@ -167,6 +170,7 @@ where
       "test".into(),
       code,
       None,
+      self.config_hash.clone()
     );
 
     if let Err(e) = res {


### PR DESCRIPTION
# Motivation
As internal plugins are just functions that return a visitor. Ideally we expect that function to be pure, the same input, the same result, however some plugins have heavy bootstrap jobs, and once they bootstrap, no need to re-bootstrap again.

`plugin_lodash` is a good example, it need to scan `node_modules` folder and then it creates a directory structure map based on that. A scan phase is super slow as it contains lots of `nodejs_resolve`, `fs::read_dir()`.

So we need a cache to store the result.

Js binding's Compiler stores an immutable configuration, when `js` call `const compiler = new Compiler(config)`, this `compiler` cannot modify its config anymore, so all plugins' input are the same config, we can make this `compiler` a cache key.

close #20 