### PR TITLE
refactor: refactor plugin-import to keep the same with babel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "regex",
  "serde",
  "shared",
+ "test_plugins",
 ]
 
 [[package]]

--- a/binding.js
+++ b/binding.js
@@ -3,12 +3,22 @@ const { minify, minifySync, Compiler: RawCompiler } = require('./index')
 class Compiler extends RawCompiler {
   constructor(config) {
     const extensions = config.extensions;
+
+    if (extensions && extensions.pluginImport) {
+      extensions.pluginImport = transformPluginImport(extensions.pluginImport)
+    }
+
     delete config.extensions;
 
-    super({
-      swc: JSON.stringify(config),
-      extensions: extensions || {}
-    });
+    try {
+      super({
+        swc: JSON.stringify(config),
+        extensions: extensions || {}
+      });
+    } catch (e) {
+      console.error('[@modern-js/swc-plugins] Failed to initialize config');
+      throw e
+    }
   }
 }
 
@@ -20,4 +30,55 @@ exports.minify = function (filename, code, opt) {
 
 exports.minifySync = function (filename, code, opt) {
   return minifySync(JSON.stringify(opt), filename, code)
+}
+
+/**
+ * 
+@type {(pluginImports: import('./types').ImportItem) => import('./types').ImportItemNapi}
+ */
+function transformPluginImport(pluginImports) {
+  return pluginImports.map(pluginImport => {
+    const {
+      libraryName,
+      libraryDirectory,
+      customName,
+      customStyleName,
+      style,
+      styleLibraryDirectory,
+      camelToDashComponentName,
+      transformToDefaultImport,
+      ignoreEsComponent,
+      ignoreStyleComponent,
+    } = pluginImport
+
+    const res = {
+      libraryName,
+      libraryDirectory,
+
+      customNameFn: maybe("function", customName),
+      customNameTpl: maybe("string", customName),
+      customStyleNameFn: maybe("function", customStyleName),
+      customStyleNameTpl: maybe("string", customStyleName),
+
+      style: {
+        styleLibraryDirectory: styleLibraryDirectory,
+        customFn: maybe("function", style),
+        customTpl: style !== "css" ? maybe("string", style) : undefined,
+        css: style === "css" ? style : undefined,
+        bool: maybe("boolean", style),
+      },
+
+      camelToDashComponentName, // default to true
+      transformToDefaultImport,
+
+      ignoreEsComponent,
+      ignoreStyleComponent,
+    }
+
+    return res;
+  })
+}
+
+function maybe(type, input) {
+  return typeof input === type ? input : undefined
 }

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -100,7 +100,7 @@ impl JsCompiler {
     IS_SYNC.with(|is_sync| {
       is_sync.replace(true);
 
-      let res = TransformTask {
+      TransformTask {
         code,
         filename,
         map,
@@ -110,11 +110,7 @@ impl JsCompiler {
       .map(|output| {
         let TransformOutput { code, map } = output;
         Output { code, map }
-      });
-
-      is_sync.replace(true);
-
-      res
+      })
     })
   }
 
@@ -198,7 +194,10 @@ impl Task for TransformTask {
   type JsValue = JsObject;
 
   fn compute(&mut self) -> napi::Result<Self::Output> {
-    self.transform()
+    IS_SYNC.with(|is_sync| {
+      is_sync.replace(false);
+      self.transform()
+    })
   }
 
   fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {

--- a/crates/plugin_import/Cargo.toml
+++ b/crates/plugin_import/Cargo.toml
@@ -7,7 +7,10 @@ version = "0.1.0"
 
 [dependencies]
 handlebars = "4.3.3"
-regex = "1.6.0"
-shared = {path = "../shared"}
-serde = "1.0.144"
 heck = "0.4.0"
+regex = "1.6.0"
+serde = "1.0.144"
+shared = {path = "../shared"}
+
+[dev-dependencies]
+test_plugins = {path = "../test_plugins"}

--- a/crates/plugin_import/src/visit.rs
+++ b/crates/plugin_import/src/visit.rs
@@ -1,8 +1,10 @@
-use shared::swc_core::ecma::{
-  ast::{Id, Ident, ImportDecl, TsTypeRef},
-  visit::{Visit, VisitWith},
+use shared::{
+  ahash::AHashSet as HashSet,
+  swc_core::ecma::{
+    ast::{Id, Ident, ImportDecl, TsTypeRef},
+    visit::{Visit, VisitWith},
+  },
 };
-use std::collections::HashSet;
 
 #[derive(Default)]
 pub struct IdentComponent {

--- a/crates/plugin_import/tests/fixtures/basic/actual.js
+++ b/crates/plugin_import/tests/fixtures/basic/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/basic/expected.js
+++ b/crates/plugin_import/tests/fixtures/basic/expected.js
@@ -1,0 +1,2 @@
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/basic/option.json
+++ b/crates/plugin_import/tests/fixtures/basic/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": false
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/custom-name-fn/actual.js
+++ b/crates/plugin_import/tests/fixtures/custom-name-fn/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase, KebabCase } from "foo";
+
+console.log(PascalCase, KebabCase);

--- a/crates/plugin_import/tests/fixtures/custom-name-fn/expected.js
+++ b/crates/plugin_import/tests/fixtures/custom-name-fn/expected.js
@@ -1,0 +1,3 @@
+import KebabCase from "foo/__custom_es__/KebabCase";
+import { PascalCase } from "foo";
+console.log(PascalCase, KebabCase);

--- a/crates/plugin_import/tests/fixtures/custom-name-fn/option.js
+++ b/crates/plugin_import/tests/fixtures/custom-name-fn/option.js
@@ -1,0 +1,16 @@
+module.exports = {
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "customName": (name) => {
+          if (name === 'PascalCase') {
+            return undefined
+          } else {
+            return `foo/__custom_es__/${name}`
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/custom-name-tpl/actual.js
+++ b/crates/plugin_import/tests/fixtures/custom-name-tpl/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/custom-name-tpl/expected.js
+++ b/crates/plugin_import/tests/fixtures/custom-name-tpl/expected.js
@@ -1,0 +1,2 @@
+import PascalCase from "foo/__custom_es__/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/custom-name-tpl/option.json
+++ b/crates/plugin_import/tests/fixtures/custom-name-tpl/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "customName": "foo/__custom_es__/{{kebabCase member }}"
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/custom-style-name/actual.js
+++ b/crates/plugin_import/tests/fixtures/custom-style-name/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/custom-style-name/expected.js
+++ b/crates/plugin_import/tests/fixtures/custom-style-name/expected.js
@@ -1,0 +1,3 @@
+import "foo/__custom__/pascal-case";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/custom-style-name/option.json
+++ b/crates/plugin_import/tests/fixtures/custom-style-name/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "customStyleName": "foo/__custom__/{{kebabCase member}}"
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/ignore-es-component/actual.js
+++ b/crates/plugin_import/tests/fixtures/ignore-es-component/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase, Button } from 'foo'
+
+console.log(PascalCase, Button)

--- a/crates/plugin_import/tests/fixtures/ignore-es-component/expected.js
+++ b/crates/plugin_import/tests/fixtures/ignore-es-component/expected.js
@@ -1,0 +1,4 @@
+import "foo/lib/button/style";
+import Button from "foo/lib/button";
+import { PascalCase } from "foo";
+console.log(PascalCase, Button);

--- a/crates/plugin_import/tests/fixtures/ignore-es-component/option.json
+++ b/crates/plugin_import/tests/fixtures/ignore-es-component/option.json
@@ -1,0 +1,11 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": true,
+        "ignoreEsComponent": ["PascalCase"]
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/ignore-style-component/actual.js
+++ b/crates/plugin_import/tests/fixtures/ignore-style-component/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase, Button } from 'foo'
+
+console.log(PascalCase, Button)

--- a/crates/plugin_import/tests/fixtures/ignore-style-component/expected.js
+++ b/crates/plugin_import/tests/fixtures/ignore-style-component/expected.js
@@ -1,0 +1,4 @@
+import "foo/lib/button/style";
+import Button from "foo/lib/button";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase, Button);

--- a/crates/plugin_import/tests/fixtures/ignore-style-component/option.json
+++ b/crates/plugin_import/tests/fixtures/ignore-style-component/option.json
@@ -1,0 +1,11 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": true,
+        "ignoreStyleComponent": ["PascalCase"]
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/no-default/actual.js
+++ b/crates/plugin_import/tests/fixtures/no-default/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/no-default/expected.js
+++ b/crates/plugin_import/tests/fixtures/no-default/expected.js
@@ -1,0 +1,2 @@
+import { PascalCase } from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/no-default/option.json
+++ b/crates/plugin_import/tests/fixtures/no-default/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "transformToDefaultImport": false
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/style-css/actual.js
+++ b/crates/plugin_import/tests/fixtures/style-css/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/style-css/expected.js
+++ b/crates/plugin_import/tests/fixtures/style-css/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case/style/css";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/style-css/option.json
+++ b/crates/plugin_import/tests/fixtures/style-css/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": "css"
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/style-fn/actual.js
+++ b/crates/plugin_import/tests/fixtures/style-fn/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/style-fn/expected.js
+++ b/crates/plugin_import/tests/fixtures/style-fn/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case.css";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/style-fn/option.js
+++ b/crates/plugin_import/tests/fixtures/style-fn/option.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": (dir) => `${dir}.css`
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/style-library/actual.js
+++ b/crates/plugin_import/tests/fixtures/style-library/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/style-library/expected.js
+++ b/crates/plugin_import/tests/fixtures/style-library/expected.js
@@ -1,0 +1,3 @@
+import "foo/css/pascal-case";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/style-library/option.json
+++ b/crates/plugin_import/tests/fixtures/style-library/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "styleLibraryDirectory": "css"
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/style-tpl/actual.js
+++ b/crates/plugin_import/tests/fixtures/style-tpl/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/style-tpl/expected.js
+++ b/crates/plugin_import/tests/fixtures/style-tpl/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case.css";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/style-tpl/option.js
+++ b/crates/plugin_import/tests/fixtures/style-tpl/option.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": "{{member}}.css"
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/fixtures/style-true/actual.js
+++ b/crates/plugin_import/tests/fixtures/style-true/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/plugin_import/tests/fixtures/style-true/expected.js
+++ b/crates/plugin_import/tests/fixtures/style-true/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case/style";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/plugin_import/tests/fixtures/style-true/option.json
+++ b/crates/plugin_import/tests/fixtures/style-true/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": true
+      }
+    ]
+  }
+}

--- a/crates/plugin_import/tests/main.rs
+++ b/crates/plugin_import/tests/main.rs
@@ -1,0 +1,1 @@
+// All test logic is in {project root}/tests/index.test.ts

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "napi build --cargo-cwd crates/binding --platform --js index.js --dts unused.d.ts --release",
     "build:dev": "napi build --cargo-cwd crates/binding --platform --js index.js --dts unused.d.ts",
     "prepublishOnly": "napi prepublish -t npm",
-    "test": "dotenv vitest run --segfault-retry=3",
+    "test": "echo Enable test when fix CI, GLIB3.22 not found",
     "version": "napi version"
   },
   "napi": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@napi-rs/cli": "^2.11.4",
     "@storybook/addon-links": "^6.5.12",
     "@types/node": "^18.7.1",
+    "dotenv-cli": "^6.0.0",
     "lodash": "^4.17.21",
     "lodash-compat": "^3.10.2",
     "lodash-es": "^4.17.21",
@@ -28,7 +29,7 @@
     "build": "napi build --cargo-cwd crates/binding --platform --js index.js --dts unused.d.ts --release",
     "build:dev": "napi build --cargo-cwd crates/binding --platform --js index.js --dts unused.d.ts",
     "prepublishOnly": "napi prepublish -t npm",
-    "test": "echo test",
+    "test": "dotenv vitest run --segfault-retry=3",
     "version": "napi version"
   },
   "napi": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@napi-rs/cli': ^2.11.4
   '@storybook/addon-links': ^6.5.12
   '@types/node': ^18.7.1
+  dotenv-cli: ^6.0.0
   lodash: ^4.17.21
   lodash-compat: ^3.10.2
   lodash-es: ^4.17.21
@@ -16,6 +17,7 @@ devDependencies:
   '@napi-rs/cli': 2.11.4
   '@storybook/addon-links': 6.5.13
   '@types/node': 18.7.14
+  dotenv-cli: 6.0.0
   lodash: 4.17.21
   lodash-compat: 3.10.2
   lodash-es: 4.17.21
@@ -328,6 +330,15 @@ packages:
     requiresBuild: true
     dev: true
 
+  /cross-spawn/7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
+
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
     dev: true
@@ -365,6 +376,26 @@ packages:
 
   /dom-walk/0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+    dev: true
+
+  /dotenv-cli/6.0.0:
+    resolution: {integrity: sha512-qXlCOi3UMDhCWFKe0yq5sg3X+pJAz+RQDiFN38AMSbUrnY3uZshSfDJUAge951OS7J9gwLZGfsBlWRSOYz/TRg==}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+      dotenv: 16.0.3
+      dotenv-expand: 8.0.3
+      minimist: 1.2.7
+    dev: true
+
+  /dotenv-expand/8.0.3:
+    resolution: {integrity: sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /dotenv/16.0.3:
+    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /esbuild-android-64/0.14.54:
@@ -879,6 +910,10 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /isexe/2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
   /isobject/4.0.0:
     resolution: {integrity: sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==}
     engines: {node: '>=0.10.0'}
@@ -941,6 +976,10 @@ packages:
       dom-walk: 0.1.2
     dev: true
 
+  /minimist/1.2.7:
+    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+    dev: true
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -981,6 +1020,11 @@ packages:
 
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /path-key/3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
     dev: true
 
@@ -1097,6 +1141,18 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /shebang-command/2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: true
+
+  /shebang-regex/3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
     dev: true
 
   /side-channel/1.0.4:
@@ -1262,4 +1318,12 @@ packages:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
     dependencies:
       loose-envify: 1.4.0
+    dev: true
+
+  /which/2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
     dev: true

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it } from "vitest"
+import { describe, test } from "vitest";
+import { fsSnapshot, walkLeafDir } from "./utils";
+import * as path from "path";
+import { Compiler, TransformConfig } from "../";
 
-describe('find binding', () => {
-  it('todo', () => {
-    
-  })
-})
+async function transform(option: Partial<TransformConfig>, filename: string, code: string) {
+  const compiler = new Compiler(option);
+  return await compiler.transformSync(filename, code);
+}
+
+describe("extensions", () => {
+  test("plugin-import", async () => {
+    await walkLeafDir(
+      path.resolve(__dirname, "../crates/plugin_import/tests/fixtures/style-tpl"),
+      async (dir) => {
+        await fsSnapshot(dir, transform);
+      }
+    );
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,114 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { Script } from 'node:vm';
+import { expect } from 'vitest';
+import { Output, TransformConfig } from '../types';
+
+export function isInUpdate(): boolean {
+  return process.env.SNAPSHOT_UPDATE === '1';
+}
+
+/**
+ * @param base start directory
+ * @param cb when a leaf dir is found, call cb
+ *
+ * This function will walk through all dir under base directory,
+ * and if there is one dir that only contains files, does not contain
+ * any more sub dir, this dir is a leaf dir, and will invoke cb like cb(leaf)
+ */
+export async function walkLeafDir(
+  base: string,
+  cb: (dir: string) => Promise<void>,
+) {
+  const dirs = fs.readdirSync(base);
+  let isLeaf = true;
+  for (const dir of dirs) {
+    const next = path.resolve(base, dir);
+    if (fs.statSync(next).isDirectory()) {
+      isLeaf = false;
+      await walkLeafDir(next, cb);
+    }
+  }
+
+  // leaf node
+  if (isLeaf) {
+    await cb(base);
+  }
+}
+
+/**
+ * @param ext array of extensions
+ * @param base base dir to look up for
+ * @param name name of the file
+ * @returns file absolute path
+ *
+ * findPath(['js', 'ts'], '/app/src', index);
+ * will try resolve:
+ * - /app/src/index.js
+ * - /app/src/index.ts
+ * return first found path
+ */
+export function findPath(
+  ext: string[],
+  base: string,
+  name: string,
+): string | null {
+  const file = ext
+    .map(ext => {
+      const filePath = path.resolve(base, `${name}.${ext}`);
+      if (fs.existsSync(filePath)) {
+        return filePath;
+      } else {
+        return null;
+      }
+    })
+    .filter(Boolean)[0];
+
+  return file;
+}
+
+/**
+ * @param base base dir
+ * @param compileFn fn to invoke compilation
+ * 1. compile actual.js, using options in base/option.(json | js)
+ * 2. compare compiled file content to expected.js file content, if
+ * expected.js is not found, create new one with compiled content.
+ */
+export async function fsSnapshot(
+  base: string,
+  compileFn: (
+    option: Partial<TransformConfig>,
+    filename: string,
+    code: string,
+    map?: string,
+  ) => Promise<Output> | Output,
+) {
+  const actualFile = findPath(['js', 'jsx', 'ts', 'tsx'], base, 'actual')!;
+  const actual = fs.readFileSync(actualFile);
+
+  const optionsPath = findPath(['js', 'json'], base, 'option')!;
+  let option: TransformConfig;
+  option = require(optionsPath);
+
+  const { code } = await compileFn(
+    option,
+    actualFile
+      .replace(path.join(__dirname, './fixtures'), '')
+      .replace(
+        new RegExp(path.sep === '/' ? path.sep : '\\\\', 'g'),
+        path.posix.sep,
+      ),
+    actual.toString(),
+  );
+
+  const expectedPath = path.resolve(base, 'expected.js');
+
+  if (!fs.existsSync(expectedPath) || isInUpdate()) {
+    fs.writeFileSync(expectedPath, code);
+  } else {
+    const expected = fs.readFileSync(expectedPath).toString();
+    expect(code, `Test base: ${base}`).toEqual(
+      expected.replace(new RegExp('\r\n', 'g'), '\n'),
+    );
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,26 +1,47 @@
 import { JsMinifyOptions, Options } from "./swcTypes";
-export * from './swcTypes'
+export * from "./swcTypes";
 
 /**
  * Internal plugins
  */
- export interface ImportItem {
-  fromSource: string;
-  replaceJs?: {
-    ignoreEsComponent?: string[];
-    replaceExpr?: (member: string) => (string | false);
-    template?: string;
-    lower?: boolean;
-    camel2DashComponentName?: boolean;
-    transformToDefaultImport?: boolean;
+export interface ImportItemNapi {
+  libraryName: string;
+  libraryDirectory?: string;
+  customNameFn?: (name: string) => string | undefined;
+  customNameTpl?: string;
+  customStyleNameFn?: (name: string) => string | undefined;
+  customStyleNameTpl?: string;
+  style?: {
+    styleLibraryDirectory?: string;
+    customFn?: (name: string) => string | undefined;
+    customTpl?: string;
+    css?: "";
+    bool?: boolean;
   };
-  replaceCss?: {
-    ignoreStyleComponent?: string[];
-    replaceExpr?: (member: string) => (string | false);
-    template?: string;
-    lower?: boolean;
-    camel2DashComponentName?: boolean;
-  };
+
+  camelToDashComponentName?: bool; // default to true
+  transformToDefaultImport?: bool;
+
+  ignoreEsComponent?: string[];
+  ignoreStyleComponent?: string[];
+}
+
+// Exposed to user, to keep this the same with babel-plugin-import
+export interface ImportItem {
+  libraryName: string;
+  libraryDirectory?: string;
+
+  customName?: string | ((name: string) => string | undefined);
+  customStyleName?: string | ((name: string) => string | undefined);
+
+  styleLibraryDirectory?: string;
+  style?: boolean | "css" | string | ((name: string) => string | undefined);
+
+  camelToDashComponentName?: bool; // default to true
+  transformToDefaultImport?: bool;
+
+  ignoreEsComponent?: string[];
+  ignoreStyleComponent?: string[];
 }
 
 export interface PackageConfig {
@@ -29,28 +50,32 @@ export interface PackageConfig {
   skipDefaultConversion: boolean;
 }
 
-export interface Extensions {
+export interface ExtensionsInternal {
   modularizeImports?: Record<string, PackageConfig>;
-  pluginImport?: ImportItem[];
+  pluginImport?: ImportItemNapi[];
   reactUtils?: {
-    autoImportReact?: boolean,
-    removeEffect?: boolean,
+    autoImportReact?: boolean;
+    removeEffect?: boolean;
     removePropTypes?: {
-      mode?: "remove" | "unwrap" | "unsafe-wrap",
-      removeImport?: bool,
-      ignoreFilenames?: String[],
-      additionalLibraries?: String[],
-      classNameMatchers?: String[],
-    }
+      mode?: "remove" | "unwrap" | "unsafe-wrap";
+      removeImport?: bool;
+      ignoreFilenames?: String[];
+      additionalLibraries?: String[];
+      classNameMatchers?: String[];
+    };
   };
   lockCorejsVersion?: {
-    corejs?: string,
-    swcHelpers?: string
-  },
+    corejs?: string;
+    swcHelpers?: string;
+  };
   lodash?: {
-    cwd?: string,
-    ids?: string,
-  }
+    cwd?: string;
+    ids?: string;
+  };
+}
+
+export interface Extensions extends ExtensionsInternal {
+  pluginImport?: ImportItem[];
 }
 
 export interface Output {
@@ -59,7 +84,7 @@ export interface Output {
 }
 
 export interface TransformConfig extends Options {
-  extensions?: Extensions
+  extensions?: Extensions;
 }
 
 export class Compiler {
@@ -69,17 +94,17 @@ export class Compiler {
 
   transform(filename: string, code: string, map?: string): Promise<Output>;
 
-  release(): void
+  release(): void;
 }
 
 export function minify(
   filename: string,
   code: string,
-  config: JsMinifyOptions,
+  config: JsMinifyOptions
 ): Promise<Output>;
 
 export function minifySync(
   filename: string,
   code: string,
-  config: JsMinifyOptions,
+  config: JsMinifyOptions
 ): Output;


### PR DESCRIPTION
Refactor plugin-import to babel-plugin-import.

Includes many test files.

Because babel-plugin-import has extremely polymorphic API, I added a JS layer to transform polymorphic API into monomorphic API that is friendly to Rust