### PR TITLE
feat: support terminates the process when node.js process exit

### DIFF
--- a/crates/binding/src/exit.rs
+++ b/crates/binding/src/exit.rs
@@ -1,0 +1,26 @@
+use napi::{bindgen_prelude::AsyncTask, JsUndefined, Task};
+use napi_derive::napi;
+
+#[napi]
+/// terminate the process when node.js process.exit
+pub fn terminate_process(code: Option<i32>) -> AsyncTask<Exit> {
+  AsyncTask::new(Exit(code))
+}
+
+pub struct Exit(Option<i32>);
+
+#[napi]
+impl Task for Exit {
+  type Output = ();
+
+  type JsValue = JsUndefined;
+
+  fn compute(&mut self) -> napi::Result<Self::Output> {
+    let code = self.0.unwrap_or(0);
+    std::process::exit(code);
+  }
+
+  fn resolve(&mut self, env: napi::Env, _output: Self::Output) -> napi::Result<Self::JsValue> {
+    env.get_undefined()
+  }
+}

--- a/crates/binding/src/exit.rs
+++ b/crates/binding/src/exit.rs
@@ -3,11 +3,11 @@ use napi_derive::napi;
 
 #[napi]
 /// terminate the process when node.js process.exit
-pub fn terminate_process(code: Option<i32>) -> AsyncTask<Exit> {
+pub fn terminate_process(code: i32) -> AsyncTask<Exit> {
   AsyncTask::new(Exit(code))
 }
 
-pub struct Exit(Option<i32>);
+pub struct Exit(i32);
 
 #[napi]
 impl Task for Exit {
@@ -16,8 +16,11 @@ impl Task for Exit {
   type JsValue = JsUndefined;
 
   fn compute(&mut self) -> napi::Result<Self::Output> {
-    let code = self.0.unwrap_or(0);
-    std::process::exit(code);
+    if self.0 == 0 {
+      // It's mean that node.js exit normally, if the code equal to zero.
+      return Ok(());
+    }
+    std::process::exit(self.0);
   }
 
   fn resolve(&mut self, env: napi::Env, _output: Self::Output) -> napi::Result<Self::JsValue> {

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -4,9 +4,7 @@ use binding_types::{IntoRawConfig, TransformConfigNapi};
 use napi::{bindgen_prelude::AsyncTask, Env, JsObject, Result, Status, Task};
 
 use napi_derive::napi;
-use shared::{
-  serde_json,
-};
+use shared::serde_json;
 use swc_core::{
   base::{
     config::{JsMinifyOptions, TerserSourceMapOption},
@@ -27,6 +25,9 @@ use std::{
   },
 };
 use swc_plugins_core::types::TransformConfig;
+
+mod exit;
+pub use exit::terminate_process;
 
 // ===== Internal Rust struct under the hood =====
 pub struct Compiler {

--- a/index.js
+++ b/index.js
@@ -236,8 +236,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Compiler, minify, minifySync } = nativeBinding
+const { terminateProcess, Compiler, minify, minifySync } = nativeBinding
 
+module.exports.terminateProcess = terminateProcess
 module.exports.Compiler = Compiler
 module.exports.minify = minify
 module.exports.minifySync = minifySync


### PR DESCRIPTION
feat: support terminates the process when `node.js` process exit
