### PR TITLE
fix: fix wrong Rust toolchain on CI

### DIFF
--- a/.changeset/orange-fishes-sniff.md
+++ b/.changeset/orange-fishes-sniff.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+fix: fix wrong rust toolchain on CI

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-08-06
           profile: minimal
           override: true
 


### PR DESCRIPTION
Fix wrong toolchain in Bench CI, causes SWC failed to build