### PR TITLE
feat: add error message when not resolve .node binary

### DIFF
--- a/.changeset/nice-scissors-build.md
+++ b/.changeset/nice-scissors-build.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+feat: add error message and advice if not find any binary

--- a/binding.js
+++ b/binding.js
@@ -1,4 +1,12 @@
-const { minify, minifySync, Compiler: RawCompiler } = require('./index')
+let binding;
+try {
+  binding = require('./index')
+} catch (e) {
+  console.error("Can't find SWC binary, you can try following ways to solve this:\n1. Upgrade your Node.js version to 14.19, and reinstall dependencies.\n2. Make sure your Node.js matches your computer OS and CPU architecture, you can check that by printing `process.arch` and `process.platform`.\n")
+  throw e
+}
+
+const { minify, minifySync, Compiler: RawCompiler } = binding
 
 class Compiler extends RawCompiler {
   constructor(config) {


### PR DESCRIPTION
Before sometimes when user install in lower version of Node.js, there is a change that optional dependency will fail to be installed, add some helpful message to inform them